### PR TITLE
Remove Global Variable 'powershell_commands' in 'unattended.py' File

### DIFF
--- a/unattended.py
+++ b/unattended.py
@@ -2,9 +2,7 @@ import subprocess
 import logging
 
 logging.basicConfig(filename="WinDebloater.log", level=logging.INFO, format='%(asctime)s - %(message)s', datefmt='%d-%b-%y %H:%M:%S')
-powershell_commands = []
 def apps_uninstall():
-    global powershell_commands
     powershell_commands = [
         'Get-AppxPackage Microsoft.Microsoft3DViewer | Remove-AppxPackage',
         'Get-AppxPackage Microsoft.BingWeather | Remove-AppxPackage',


### PR DESCRIPTION
### Commit Message Body

Removed the global varibale because it wasn't being accessed anywhere in the script, therefore there isn't any reason to have it globally accessable.